### PR TITLE
check visible flag to skip invisible items

### DIFF
--- a/src/motion-transition/motion-transition.c
+++ b/src/motion-transition/motion-transition.c
@@ -107,7 +107,7 @@ static bool append_item_list(obs_scene_t *scene, obs_sceneitem_t *item_a, void *
 	if (item_b) {
 		obs_sceneitem_get_info(item_b, info_b);
 		obs_sceneitem_get_crop(item_b, crop_b);
-		transform_variation = same_transform_type(info_a, info_b);
+		transform_variation = same_transform_type(info_a, info_b) && (item_a->user_visible==item_b->user_visible);
 	}
 
 	if (transform_variation) {


### PR DESCRIPTION
If making a transition between scenes that has invisible items, the transition behavior is affected by the invisible items.
For example, having a scene on a live and changing visibility of an item on the same scene at preview side, then running motion-transition. The expected behavior is the item will vanish with motion. Actual behavior is moation does not happen.
I'd like to propose to compare 'user-visible' so that zoom-out and zoom-in will happen.